### PR TITLE
Set version with flag or env

### DIFF
--- a/esileapclient/osc/plugin.py
+++ b/esileapclient/osc/plugin.py
@@ -11,22 +11,23 @@
 #    under the License.
 
 import logging
+import argparse
 
 from osc_lib import utils
 
 
-DEFAULT_API_VERSION = '1.0'
+DEFAULT_API_VERSION = '1'
 
 # Required by the OSC plugin interface
 API_NAME = 'lease'
 API_VERSION_OPTION = 'os_lease_api_version'
 API_VERSIONS = {
-    '1.0': 'esileapclient.v1.client.Client',
+    '1': 'esileapclient.v1.client.Client',
 }
 
-OS_LEASE_API_LATEST = True
-LAST_KNOWN_API_VERSION = '1.0'
-LATEST_VERSION = '1.0'
+OS_LEAP_API_LATEST = True
+LAST_KNOWN_API_VERSION = '1'
+LATEST_VERSION = '1'
 
 
 LOG = logging.getLogger(__name__)
@@ -69,5 +70,14 @@ def build_option_parser(parser):
     :param argparse.ArgumentParser parser: The parser object that has been
         initialized by OpenStackShell.
     """
-
+    parser.add_argument(
+        '--os-lease-api-version',
+        metavar='<esileapclient-api-version>',
+        default=utils.env(
+            'OS_LEASE_API_VERSION',
+            default=DEFAULT_API_VERSION),
+        help='ESI Leap Client API version, default=' +
+             DEFAULT_API_VERSION +
+             ' (Env: OS_LEASE_API_VERSION)')
     return parser
+

--- a/esileapclient/tests/unit/osc/test_plugin.py
+++ b/esileapclient/tests/unit/osc/test_plugin.py
@@ -16,7 +16,7 @@ import testtools
 from esileapclient.osc import plugin
 from esileapclient.v1 import client
 
-API_VERSION = '1.0'
+API_VERSION = '1'
 
 
 class FakeClientManager(object):
@@ -55,7 +55,7 @@ class MakeClientTest(testtools.TestCase):
     @mock.patch.object(client, 'Client')
     def test_make_client_v1(self, mock_client):
         instance = FakeClientManager()
-        instance._api_version = {'lease': '1.0'}
+        instance._api_version = {'lease': '1'}
         plugin.make_client(instance)
         mock_client.assert_called_once_with(
             os_esileap_api_version=plugin.LATEST_VERSION,


### PR DESCRIPTION
Updates the osc plugin to allow users to pick
and explicit versoin using the flag
--os-lease-api-version or the environment
variable OS_LEASE_API_VERSION