### PR TITLE
Allow contracts to be created using offer name

### DIFF
--- a/esileapclient/common/base.py
+++ b/esileapclient/common/base.py
@@ -41,12 +41,6 @@ class Manager(object):
         """The resource name.
         """
 
-    @property
-    @abc.abstractmethod
-    def _creation_attributes(self):
-        """A list of required creation attributes for a resource type.
-        """
-
     def __init__(self, api):
         self.api = api
 
@@ -78,7 +72,7 @@ class Manager(object):
         new = {}
         invalid = []
         for (key, value) in kwargs.items():
-            if key in self._creation_attributes:
+            if key in self.resource_class._creation_attributes:
                 new[key] = value
             else:
                 invalid.append(key)
@@ -184,6 +178,12 @@ class Resource(object):
     def detailed_fields(self):
         """A dictionary of all attributes to be displayed in a
         detailed request"""
+
+    @property
+    @abc.abstractmethod
+    def _creation_attributes(self):
+        """A list of required creation attributes for a resource type.
+        """
 
     def __init__(self, manager, info):
         """Populate and bind to a manager.

--- a/esileapclient/osc/v1/lease_contract.py
+++ b/esileapclient/osc/v1/lease_contract.py
@@ -40,10 +40,10 @@ class CreateLeaseContract(command.ShowOne):
             required=False,
             help="Name of the contract being created. ")
         parser.add_argument(
-            '--offer-uuid',
-            dest='offer_uuid',
+            '--offer',
+            dest='offer_uuid_or_name',
             required=True,
-            help="UUID of the offer")
+            help="Name or UUID of the offer")
         parser.add_argument(
             '--status',
             dest='status',
@@ -75,7 +75,7 @@ class CreateLeaseContract(command.ShowOne):
 
         lease_client = self.app.client_manager.lease
 
-        field_list = CONTRACT_RESOURCE.detailed_fields.keys()
+        field_list = CONTRACT_RESOURCE._creation_attributes
 
         fields = dict((k, v) for (k, v) in vars(parsed_args).items()
                       if k in field_list and v is not None)
@@ -104,25 +104,21 @@ class ListLeaseContract(command.Lister):
             default=False,
             help="Show detailed information about the contracts.",
             action='store_true')
-
         parser.add_argument(
             '--all',
             default=False,
             help="Show all contracts in the database. For admin use only.",
             action='store_true')
-
         parser.add_argument(
             '--status',
             dest='status',
             required=False,
             help="Show all contracts with given status.")
-
         parser.add_argument(
             '--offer-uuid',
             dest='offer_uuid',
             required=False,
             help="Show all contracts with given offer_uuid.")
-
         parser.add_argument(
             '--time-range',
             dest='time_range',
@@ -133,13 +129,11 @@ class ListLeaseContract(command.Lister):
                  "Must pass in two valid datetime strings."
                  "Example: --time-range 2020-06-30T00:00:00"
                  "2021-06-30T00:00:00")
-
         parser.add_argument(
             '--project-id',
             dest='project_id',
             required=False,
             help="Show all contracts owned by given project id.")
-
         parser.add_argument(
             '--owner',
             dest='owner',

--- a/esileapclient/osc/v1/lease_offer.py
+++ b/esileapclient/osc/v1/lease_offer.py
@@ -81,7 +81,7 @@ class CreateLeaseOffer(command.ShowOne):
 
         lease_client = self.app.client_manager.lease
 
-        field_list = OFFER_RESOURCE.detailed_fields.keys()
+        field_list = OFFER_RESOURCE._creation_attributes
 
         fields = dict((k, v) for (k, v) in vars(parsed_args).items()
                       if k in field_list and v is not None)
@@ -110,13 +110,11 @@ class ListLeaseOffer(command.Lister):
             default=False,
             help="Show detailed information about the offers.",
             action='store_true')
-
         parser.add_argument(
             '--status',
             dest='status',
             required=False,
             help="Show all offers with given status.")
-
         parser.add_argument(
             '--time-range',
             dest='time_range',
@@ -127,7 +125,6 @@ class ListLeaseOffer(command.Lister):
                  "Must pass in two valid datetime strings."
                  "Example: --time-range 2020-06-30T00:00:00"
                  "2021-06-30T00:00:00")
-
         parser.add_argument(
             '--availability-range',
             dest='availability_range',
@@ -139,19 +136,16 @@ class ListLeaseOffer(command.Lister):
                  "strings."
                  "Example: --availability-range 2020-06-30T00:00:00"
                  "2021-06-30T00:00:00")
-
         parser.add_argument(
             '--project-id',
             dest='project_id',
             required=False,
             help="Show all offers owned by given project id.")
-
         parser.add_argument(
             '--resource-type',
             dest='resource_type',
             required=False,
             help="Show all offers with given resource-type.")
-
         parser.add_argument(
             '--resource-uuid',
             dest='resource_uuid',

--- a/esileapclient/tests/unit/common/test_base.py
+++ b/esileapclient/tests/unit/common/test_base.py
@@ -71,13 +71,14 @@ class TestableResource(base.Resource):
         'attribute3': 'Attribute 3',
     }
 
+    _creation_attributes = ['attribute1', 'attribute2']
+
     def __repr__(self):
         return "<TestableResource %s>" % self._info
 
 
 class TestableManager(base.Manager):
     resource_class = TestableResource
-    _creation_attributes = ['attribute1', 'attribute2']
     _resource_name = 'testableresources'
 
 

--- a/esileapclient/tests/unit/osc/v1/test_lease_contract.py
+++ b/esileapclient/tests/unit/osc/v1/test_lease_contract.py
@@ -46,7 +46,7 @@ class TestCreateLeaseContract(TestLeaseContract):
         arglist = [
             '--end-time', lease_fakes.lease_end_time,
             '--name', lease_fakes.lease_contract_name,
-            '--offer-uuid', lease_fakes.lease_offer_uuid,
+            '--offer', lease_fakes.lease_offer_uuid,
             '--properties', lease_fakes.lease_properties,
             '--start-time', lease_fakes.lease_start_time,
             '--status', lease_fakes.lease_status,
@@ -55,7 +55,7 @@ class TestCreateLeaseContract(TestLeaseContract):
         verifylist = [
             ('end_time', lease_fakes.lease_end_time),
             ('name', lease_fakes.lease_contract_name),
-            ('offer_uuid', lease_fakes.lease_offer_uuid),
+            ('offer_uuid_or_name', lease_fakes.lease_offer_uuid),
             ('properties', lease_fakes.lease_properties),
             ('start_time', lease_fakes.lease_start_time),
             ('status', lease_fakes.lease_status),
@@ -68,7 +68,7 @@ class TestCreateLeaseContract(TestLeaseContract):
         args = {
             'end_time': lease_fakes.lease_end_time,
             'name': lease_fakes.lease_contract_name,
-            'offer_uuid': lease_fakes.lease_offer_uuid,
+            'offer_uuid_or_name': lease_fakes.lease_offer_uuid,
             'properties': json.loads(lease_fakes.lease_properties),
             'start_time': lease_fakes.lease_start_time,
             'status': lease_fakes.lease_status,

--- a/esileapclient/v1/contract.py
+++ b/esileapclient/v1/contract.py
@@ -40,15 +40,15 @@ class Contract(base.Resource):
         'status': "Status",
     }
 
+    _creation_attributes = ['start_time', 'end_time', 'status', 'name',
+                            'offer_uuid_or_name', 'properties', 'project_id']
+
     def __repr__(self):
         return "<Contract %s>" % self._info
 
 
 class ContractManager(base.Manager):
     resource_class = Contract
-    _creation_attributes = ['start_time', 'end_time', 'status', 'name',
-                            'offer_uuid', 'properties', 'project_id']
-
     _resource_name = 'contracts'
 
     def create(self, os_esileap_api_version=None, **kwargs):

--- a/esileapclient/v1/offer.py
+++ b/esileapclient/v1/offer.py
@@ -44,16 +44,16 @@ class Offer(base.Resource):
         'availabilities': "Availabilities",
     }
 
+    _creation_attributes = ['resource_type', 'resource_uuid',
+                            'start_time', 'end_time', 'status',
+                            'project_id', 'properties', 'name']
+
     def __repr__(self):
         return "<Offer %s>" % self._info
 
 
 class OfferManager(base.Manager):
     resource_class = Offer
-    _creation_attributes = ['resource_type', 'resource_uuid',
-                            'start_time', 'end_time', 'status',
-                            'project_id', 'properties', 'name']
-
     _resource_name = 'offers'
 
     def create(self, os_esileap_api_version=None, **kwargs):


### PR DESCRIPTION
Updated the client to support creation of contracts
by the name field of an Offer.