### PR TITLE
Updated args for create commands

### DIFF
--- a/esileapclient/osc/v1/lease.py
+++ b/esileapclient/osc/v1/lease.py
@@ -30,10 +30,6 @@ class CreateLease(command.ShowOne):
         parser = super(CreateLease, self).get_parser(prog_name)
 
         parser.add_argument(
-            "resource_type",
-            metavar="<resource_type>",
-            help="Resource type")
-        parser.add_argument(
             "resource_uuid",
             metavar="<resource_uuid>",
             help="Resource UUID")
@@ -52,21 +48,21 @@ class CreateLease(command.ShowOne):
             required=False,
             help="Name of the lease being created. ")
         parser.add_argument(
-            '--status',
-            dest='status',
-            required=False,
-            help='State which the lease should be created in.')
-        parser.add_argument(
-            '--start-time',
-            dest='start_time',
-            required=False,
-            help="Time when the resource will become usable.")
-        parser.add_argument(
             '--properties',
             dest='properties',
             required=False,
             help="Record arbitrary key/value resource property "
                  "information. Pass in as a json object.")
+        parser.add_argument(
+            '--resource-type',
+            dest='resource_type',
+            required=False,
+            help="Use this resource type instead of the default.")
+        parser.add_argument(
+            '--start-time',
+            dest='start_time',
+            required=False,
+            help="Time when the resource will become usable.")
 
         return parser
 

--- a/esileapclient/osc/v1/offer.py
+++ b/esileapclient/osc/v1/offer.py
@@ -31,6 +31,10 @@ class CreateOffer(command.ShowOne):
         parser = super(CreateOffer, self).get_parser(prog_name)
 
         parser.add_argument(
+            "resource_uuid",
+            metavar="<resource_uuid>",
+            help="Resource UUID")
+        parser.add_argument(
             '--end-time',
             dest='end_time',
             required=False,
@@ -42,39 +46,21 @@ class CreateOffer(command.ShowOne):
             required=False,
             help="Name of the offer being created. ")
         parser.add_argument(
-            '--resource-type',
-            dest='resource_type',
-            required=True,
-            help='Type of the resource to be offered.')
-        parser.add_argument(
-            '--resource-uuid',
-            dest='resource_uuid',
-            required=True,
-            help="UUID of the resource")
-        parser.add_argument(
-            '--status',
-            dest='status',
-            required=False,
-            help='State which the offer should be created in.')
-        parser.add_argument(
-            '--start-time',
-            dest='start_time',
-            required=False,
-            help="Time when the offer will be made 'available'.")
-        parser.add_argument(
-            '--project-id',
-            dest='project_id',
-            required=False,
-            help="Project ID to assign ownership of the offer to."
-                 "If this attribute is not set, ESI-Leap will set the "
-                 "project_id to the id of the user which invoked the "
-                 "command.")
-        parser.add_argument(
             '--properties',
             dest='properties',
             required=False,
             help="Record arbitrary key/value resource property "
                  "information. Pass in as a json object.")
+        parser.add_argument(
+            '--resource-type',
+            dest='resource_type',
+            required=False,
+            help="Use this resource type instead of the default.")
+        parser.add_argument(
+            '--start-time',
+            dest='start_time',
+            required=False,
+            help="Time when the offer will be made 'available'.")
 
         return parser
 

--- a/esileapclient/tests/unit/osc/v1/test_lease.py
+++ b/esileapclient/tests/unit/osc/v1/test_lease.py
@@ -44,14 +44,13 @@ class TestCreateLease(TestLease):
     def test_lease_create(self):
 
         arglist = [
-            fakes.lease_resource_type,
             fakes.lease_resource_uuid,
             fakes.lease_project_id,
             '--end-time', fakes.lease_end_time,
             '--name', fakes.lease_name,
             '--properties', fakes.lease_properties,
+            '--resource-type', fakes.lease_resource_type,
             '--start-time', fakes.lease_start_time,
-            '--status', fakes.lease_status,
         ]
 
         verifylist = [
@@ -62,7 +61,6 @@ class TestCreateLease(TestLease):
             ('resource_type', fakes.lease_resource_type),
             ('resource_uuid', fakes.lease_resource_uuid),
             ('start_time', fakes.lease_start_time),
-            ('status', fakes.lease_status),
         ]
 
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
@@ -77,7 +75,6 @@ class TestCreateLease(TestLease):
             'name': fakes.lease_name,
             'properties': json.loads(fakes.lease_properties),
             'start_time': fakes.lease_start_time,
-            'status': fakes.lease_status,
         }
 
         self.lease_mock.lease.create.assert_called_once_with(**args)

--- a/esileapclient/tests/unit/osc/v1/test_offer.py
+++ b/esileapclient/tests/unit/osc/v1/test_offer.py
@@ -41,16 +41,15 @@ class TestOfferCreate(TestOffer):
         # Get the command object to test
         self.cmd = offer.CreateOffer(self.app, None)
 
-    def test_market_offer_create(self):
+    def test_offer_create(self):
 
         arglist = [
+            fakes.lease_resource_uuid,
             '--end-time', fakes.lease_end_time,
             '--name', fakes.offer_name,
             '--properties', fakes.lease_properties,
             '--resource-type', fakes.lease_resource_type,
-            '--resource-uuid', fakes.lease_resource_uuid,
             '--start-time', fakes.lease_start_time,
-            '--status', fakes.lease_status,
         ]
 
         verifylist = [
@@ -60,7 +59,6 @@ class TestOfferCreate(TestOffer):
             ('resource_type', fakes.lease_resource_type),
             ('resource_uuid', fakes.lease_resource_uuid),
             ('start_time', fakes.lease_start_time),
-            ('status', fakes.lease_status),
         ]
 
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
@@ -74,7 +72,6 @@ class TestOfferCreate(TestOffer):
             'resource_type': fakes.lease_resource_type,
             'resource_uuid': fakes.lease_resource_uuid,
             'start_time': fakes.lease_start_time,
-            'status': fakes.lease_status,
         }
 
         self.lease_mock.offer.create.assert_called_once_with(**args)
@@ -202,7 +199,7 @@ class TestOfferShow(TestOffer):
 
         self.cmd = offer.ShowOffer(self.app, None)
 
-    def test_market_offer_show(self):
+    def test_offer_show(self):
         arglist = [fakes.offer_uuid]
         verifylist = [('uuid', fakes.offer_uuid)]
 


### PR DESCRIPTION
This change makes required arguments explicit, and also removes
the project_id and status options during creation, as neither
should ever be used.