### PR TITLE
Allow name of resource or project to be used in place of UUID

### DIFF
--- a/esileapclient/osc/v1/lease.py
+++ b/esileapclient/osc/v1/lease.py
@@ -31,12 +31,12 @@ class CreateLease(command.ShowOne):
 
         parser.add_argument(
             "resource_uuid",
-            metavar="<resource_uuid>",
-            help="Resource UUID")
+            metavar="<resource>",
+            help="Resource UUID or name")
         parser.add_argument(
             'project_id',
-            metavar="<project_id>",
-            help="Project leasing the resource.")
+            metavar="<project>",
+            help="Project ID or name leasing the resource.")
         parser.add_argument(
             '--end-time',
             dest='end_time',
@@ -123,16 +123,16 @@ class ListLease(command.Lister):
                  "Example: --time-range 2020-06-30T00:00:00"
                  "2021-06-30T00:00:00")
         parser.add_argument(
-            '--project-id',
+            '--project',
             dest='project_id',
             required=False,
-            help="Show all leases owned by given project id.")
+            help="Show all leases owned by given project ID or name.")
         parser.add_argument(
-            '--owner-id',
+            '--owner',
             dest='owner_id',
             required=False,
             help="Show all leases relevant to an offer owner "
-                 "by the owner's project_id.")
+                 "by the owner's project ID or name.")
         parser.add_argument(
             '--resource-type',
             dest='resource_type',

--- a/esileapclient/osc/v1/offer.py
+++ b/esileapclient/osc/v1/offer.py
@@ -41,7 +41,7 @@ class CreateOffer(command.ShowOne):
             help="Time when the offer will expire and no longer be "
                  "'available'.")
         parser.add_argument(
-            '--lessee-id',
+            '--lessee',
             dest='lessee_id',
             required=False,
             help="Project subtree to which this offer will be limited.")
@@ -129,10 +129,10 @@ class ListOffer(command.Lister):
                  "Example: --availability-range 2020-06-30T00:00:00"
                  "2021-06-30T00:00:00")
         parser.add_argument(
-            '--project-id',
+            '--project',
             dest='project_id',
             required=False,
-            help="Show all offers owned by given project id.")
+            help="Show all offers owned by given project ID or name.")
         parser.add_argument(
             '--resource-type',
             dest='resource_type',

--- a/esileapclient/tests/unit/osc/v1/test_offer.py
+++ b/esileapclient/tests/unit/osc/v1/test_offer.py
@@ -45,7 +45,7 @@ class TestOfferCreate(TestOffer):
         arglist = [
             fakes.lease_resource_uuid,
             '--end-time', fakes.lease_end_time,
-            '--lessee-id', fakes.offer_lessee_id,
+            '--lessee', fakes.offer_lessee_id,
             '--name', fakes.offer_name,
             '--properties', fakes.lease_properties,
             '--resource-type', fakes.lease_resource_type,


### PR DESCRIPTION
Note that this is a cosmetic change, only affecting the help text.