### PR TITLE
Apply property filters

### DIFF
--- a/esileapclient/common/utils.py
+++ b/esileapclient/common/utils.py
@@ -1,0 +1,74 @@
+import re
+import operator
+import logging
+
+# Configure the logger
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Define constants for operator pattern and filter pattern
+OPS = {
+    '>=': operator.ge,
+    '<=': operator.le,
+    '>': operator.gt,
+    '<': operator.lt,
+    '=': operator.eq,
+}
+
+OPERATOR_PATTERN = '|'.join(re.escape(op) for op in OPS.keys())
+FILTER_PATTERN = re.compile(rf'([^><=]+)({OPERATOR_PATTERN})(.+)')
+
+
+def convert_value(value_str):
+    """Convert a value string to an appropriate type for comparison."""
+    try:
+        return int(value_str)
+    except ValueError:
+        try:
+            return float(value_str)
+        except ValueError:
+            return value_str
+
+
+def parse_property_filter(filter_str):
+    """Parse a property filter string into a key, operator, and value."""
+    match = FILTER_PATTERN.match(filter_str)
+    if not match:
+        raise ValueError(f"Invalid property filter format: {filter_str}")
+    key, op_str, value_str = match.groups()
+    if op_str not in OPS:
+        raise ValueError(f"Invalid operator in property filter: {op_str}")
+    value = convert_value(value_str)
+    return key.strip(), OPS[op_str], value
+
+
+def node_matches_property_filters(node, property_filters):
+    """Check if a node matches all property filters."""
+    properties = node.get('resource_properties', node.get('properties', {}))
+    for key, op, value in property_filters:
+        if key not in properties:
+            return False
+        node_value = convert_value(properties.get(key, ''))
+        if not op(node_value, value):
+            return False
+    return True
+
+
+def filter_nodes_by_properties(nodes, properties):
+    """Filter a list of nodes based on property filters."""
+    if not properties:
+        return nodes
+    property_filters = []
+    for prop in properties:
+        try:
+            property_filters.append(parse_property_filter(prop))
+        except ValueError as e:
+            LOG.error(f"Error parsing property filter '{prop}': {e}")
+            raise
+
+    filtered_nodes = [
+        node for node in nodes
+        if node_matches_property_filters(node, property_filters)
+    ]
+
+    return filtered_nodes

--- a/esileapclient/tests/unit/common/test_utils.py
+++ b/esileapclient/tests/unit/common/test_utils.py
@@ -1,0 +1,91 @@
+import unittest
+from esileapclient.common import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def setUp(self):
+        self.nodes = [
+            {'properties': {'cpus': '40', 'memory_mb': '131072'}},
+            {'properties': {'cpus': '80', 'memory_mb': '262144'}},
+            {'properties': {'cpus': '20', 'memory_mb': '65536'}},
+        ]
+
+    def test_convert_value(self):
+        self.assertEqual(utils.convert_value('10'), 10)
+        self.assertEqual(utils.convert_value('10.5'), 10.5)
+        self.assertEqual(utils.convert_value('text'), 'text')
+
+    def test_parse_property_filter(self):
+        key, op, value = utils.parse_property_filter('cpus>=40')
+        self.assertEqual(key, 'cpus')
+        self.assertEqual(op, utils.OPS['>='])
+        self.assertEqual(value, 40)
+
+        key, op, value = utils.parse_property_filter('memory_mb<=131072')
+        self.assertEqual(key, 'memory_mb')
+        self.assertEqual(op, utils.OPS['<='])
+        self.assertEqual(value, 131072)
+
+        # Test for invalid filter format
+        self.assertRaisesRegex(
+            ValueError,
+            'Invalid property filter format: invalid_filter',
+            utils.parse_property_filter, 'invalid_filter'
+        )
+
+        # Test for invalid operator
+        self.assertRaisesRegex(
+            ValueError,
+            'Invalid property filter format: cpus!40',
+            utils.parse_property_filter, 'cpus!40'
+        )
+
+    def test_node_matches_property_filters(self):
+        filters = [
+            utils.parse_property_filter('cpus>=40'),
+            utils.parse_property_filter('memory_mb>=131072')
+        ]
+        self.assertTrue(utils.node_matches_property_filters(
+            self.nodes[1], filters))
+        self.assertFalse(utils.node_matches_property_filters(
+            self.nodes[2], filters))
+
+        # Test for non-existent property
+        filters = [utils.parse_property_filter('non_existent_property>=100')]
+        self.assertFalse(utils.node_matches_property_filters(
+            self.nodes[0], filters))
+
+    def test_filter_nodes_by_properties(self):
+        properties = ['cpus>=40']
+        filtered_nodes = utils.filter_nodes_by_properties(
+            self.nodes, properties)
+        self.assertEqual(len(filtered_nodes), 2)
+
+        properties = ['memory_mb<=131072']
+        filtered_nodes = utils.filter_nodes_by_properties(
+            self.nodes, properties)
+        self.assertEqual(len(filtered_nodes), 2)
+
+        properties = ['cpus>100']
+        filtered_nodes = utils.filter_nodes_by_properties(
+            self.nodes, properties)
+        self.assertEqual(len(filtered_nodes), 0)
+
+        properties = ['cpus<40']
+        filtered_nodes = utils.filter_nodes_by_properties(
+            self.nodes, properties)
+        self.assertEqual(len(filtered_nodes), 1)
+        self.assertEqual(filtered_nodes[0]['properties']['cpus'], '20')
+
+        # Test for error parsing property filter
+        properties = ['invalid_filter']
+        with self.assertLogs('esileapclient.common.utils', level='ERROR') as c:
+            self.assertRaisesRegex(
+                ValueError,
+                "Invalid property filter format: invalid_filter",
+                utils.filter_nodes_by_properties, self.nodes, properties
+            )
+            self.assertTrue(any(
+                "Invalid property filter format: invalid_filter" in message
+                for message in c.output))

--- a/esileapclient/tests/unit/osc/v1/fakes.py
+++ b/esileapclient/tests/unit/osc/v1/fakes.py
@@ -43,7 +43,16 @@ event_id = 7
 event_type = 'fake.event'
 event_time = "3000-07-01T12"
 object_type = 'lease'
-node_properties = {'cpu': '40', 'traits': ['trait1', 'trait2']}
+node_properties = {
+    'cpus': '40',
+    'memory_mb': '131072',
+    'local_gb': '1200',
+    'cpu_arch': 'x86_64',
+    'vendor': 'fake-vendor',
+    'cpu_model_name': 'fake-model',
+    'cpu_frequency': '2000.0',
+    'traits': ['trait1', 'trait2']
+    }
 
 OFFER = {
     'availabilities': json.loads(lease_availabilities),

--- a/esileapclient/tests/unit/osc/v1/test_lease.py
+++ b/esileapclient/tests/unit/osc/v1/test_lease.py
@@ -13,6 +13,7 @@
 import copy
 import json
 from osc_lib.tests import utils as osctestutils
+from unittest import mock
 
 from esileapclient.osc.v1 import lease
 from esileapclient.tests.unit.osc.v1 import base
@@ -181,6 +182,33 @@ class TestLeaseList(TestLease):
                      ),)
         self.assertEqual(datalist, tuple(data))
 
+    @mock.patch('esileapclient.common.utils.filter_nodes_by_properties')
+    def test_lease_list_with_property_filter(self, mock_filter_nodes):
+        arglist = ['--property', 'cpus>=40']
+        verifylist = [('properties', ['cpus>=40'])]
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+        columns, data = self.cmd.take_action(parsed_args)
+
+        filters = {
+            'status': parsed_args.status,
+            'offer_uuid': parsed_args.offer_uuid,
+            'start_time': str(parsed_args.time_range[0]) if
+            parsed_args.time_range else None,
+            'end_time': str(parsed_args.time_range[1]) if
+            parsed_args.time_range else None,
+            'project_id': parsed_args.project_id,
+            'owner_id': parsed_args.owner_id,
+            'view': 'all' if parsed_args.all else None,
+            'resource_type': parsed_args.resource_type,
+            'resource_uuid': parsed_args.resource_uuid,
+            'resource_class': parsed_args.resource_class,
+            'purpose': parsed_args.purpose
+        }
+
+        self.client_mock.leases.assert_called_with(**filters)
+        mock_filter_nodes.assert_called_with(mock.ANY, parsed_args.properties)
+
     def test_lease_list_long(self):
         arglist = ['--long']
         verifylist = [('long', True)]
@@ -241,6 +269,33 @@ class TestLeaseList(TestLease):
                      fakes.lease_purpose,
                      ),)
         self.assertEqual(datalist, tuple(data))
+
+    @mock.patch('esileapclient.common.utils.filter_nodes_by_properties')
+    def test_lease_list_long_with_property_filter(self, mock_filter_nodes):
+        arglist = ['--long', '--property', 'memory_mb<=262144']
+        verifylist = [('long', True), ('properties', ['memory_mb<=262144'])]
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+        columns, data = self.cmd.take_action(parsed_args)
+
+        filters = {
+            'status': parsed_args.status,
+            'offer_uuid': parsed_args.offer_uuid,
+            'start_time': str(parsed_args.time_range[0]) if
+            parsed_args.time_range else None,
+            'end_time': str(parsed_args.time_range[1]) if
+            parsed_args.time_range else None,
+            'project_id': parsed_args.project_id,
+            'owner_id': parsed_args.owner_id,
+            'view': 'all' if parsed_args.all else None,
+            'resource_type': parsed_args.resource_type,
+            'resource_uuid': parsed_args.resource_uuid,
+            'resource_class': parsed_args.resource_class,
+            'purpose': parsed_args.purpose
+        }
+
+        self.client_mock.leases.assert_called_with(**filters)
+        mock_filter_nodes.assert_called_with(mock.ANY, parsed_args.properties)
 
 
 class TestLeaseShow(TestLease):

--- a/esileapclient/tests/unit/osc/v1/test_node.py
+++ b/esileapclient/tests/unit/osc/v1/test_node.py
@@ -11,6 +11,7 @@
 #    under the License.
 
 import copy
+from unittest import mock
 
 from esileapclient.osc.v1 import node
 from esileapclient.tests.unit.osc.v1 import base
@@ -125,3 +126,37 @@ class TestNodeList(TestNode):
                      '', '', '', ''
                      ),)
         self.assertEqual(datalist, tuple(data))
+
+    @mock.patch('esileapclient.common.utils.filter_nodes_by_properties')
+    def test_node_list_with_property_filter(self, mock_filter_nodes):
+        arglist = ['--property', 'cpus>=40']
+        verifylist = [('properties', ['cpus>=40'])]
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+        columns, data = self.cmd.take_action(parsed_args)
+
+        filters = {
+            'resource_class': parsed_args.resource_class,
+            'owner': parsed_args.owner,
+            'lessee': parsed_args.lessee
+        }
+
+        self.client_mock.nodes.assert_called_with(**filters)
+        mock_filter_nodes.assert_called_with(mock.ANY, parsed_args.properties)
+
+    @mock.patch('esileapclient.common.utils.filter_nodes_by_properties')
+    def test_node_list_long_with_property_filter(self, mock_filter_nodes):
+        arglist = ['--long', '--property', 'memory_mb>=131072']
+        verifylist = [('long', True), ('properties', ['memory_mb>=131072'])]
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+        columns, data = self.cmd.take_action(parsed_args)
+
+        filters = {
+            'resource_class': parsed_args.resource_class,
+            'owner': parsed_args.owner,
+            'lessee': parsed_args.lessee
+        }
+
+        self.client_mock.nodes.assert_called_with(**filters)
+        mock_filter_nodes.assert_called_with(mock.ANY, parsed_args.properties)

--- a/esileapclient/tests/unit/osc/v1/test_offer.py
+++ b/esileapclient/tests/unit/osc/v1/test_offer.py
@@ -13,6 +13,7 @@
 import copy
 import json
 from osc_lib.tests import utils as osctestutils
+from unittest import mock
 
 from esileapclient.osc.v1 import offer
 from esileapclient.tests.unit.osc.v1 import base
@@ -137,6 +138,33 @@ class TestOfferList(TestOffer):
                      ),)
         self.assertEqual(datalist, tuple(data))
 
+    @mock.patch('esileapclient.common.utils.filter_nodes_by_properties')
+    def test_offer_list_with_property_filter(self, mock_filter_nodes):
+        arglist = ['--property', 'cpus>=40']
+        verifylist = [('properties', ['cpus>=40'])]
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+        columns, data = self.cmd.take_action(parsed_args)
+
+        filters = {
+            'status': parsed_args.status,
+            'start_time': str(parsed_args.time_range[0]) if
+            parsed_args.time_range else None,
+            'end_time': str(parsed_args.time_range[1]) if
+            parsed_args.time_range else None,
+            'available_start_time': str(parsed_args.availability_range[0]) if
+            parsed_args.availability_range else None,
+            'available_end_time': str(parsed_args.availability_range[1]) if
+            parsed_args.availability_range else None,
+            'project_id': parsed_args.project_id,
+            'resource_type': parsed_args.resource_type,
+            'resource_uuid': parsed_args.resource_uuid,
+            'resource_class': parsed_args.resource_class
+        }
+
+        self.client_mock.offers.assert_called_with(**filters)
+        mock_filter_nodes.assert_called_with(mock.ANY, parsed_args.properties)
+
     def test_offer_list_long(self):
         arglist = ['--long']
         verifylist = [('long', True)]
@@ -191,6 +219,33 @@ class TestOfferList(TestOffer):
                      fakes.parent_lease_uuid
                      ),)
         self.assertEqual(datalist, tuple(data))
+
+    @mock.patch('esileapclient.common.utils.filter_nodes_by_properties')
+    def test_offer_list_long_with_property_filter(self, mock_filter_nodes):
+        arglist = ['--long', '--property', 'memory_mb>=131072']
+        verifylist = [('long', True), ('properties', ['memory_mb>=131072'])]
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+        columns, data = self.cmd.take_action(parsed_args)
+
+        filters = {
+            'status': parsed_args.status,
+            'start_time': str(parsed_args.time_range[0]) if
+            parsed_args.time_range else None,
+            'end_time': str(parsed_args.time_range[1]) if
+            parsed_args.time_range else None,
+            'available_start_time': str(parsed_args.availability_range[0]) if
+            parsed_args.availability_range else None,
+            'available_end_time': str(parsed_args.availability_range[1]) if
+            parsed_args.availability_range else None,
+            'project_id': parsed_args.project_id,
+            'resource_type': parsed_args.resource_type,
+            'resource_uuid': parsed_args.resource_uuid,
+            'resource_class': parsed_args.resource_class
+        }
+
+        self.client_mock.offers.assert_called_with(**filters)
+        mock_filter_nodes.assert_called_with(mock.ANY, parsed_args.properties)
 
 
 class TestOfferShow(TestOffer):


### PR DESCRIPTION


This commit introduces support for filtering nodes based on properties in the node listing command and adds corresponding test cases to ensure the functionality works as expected.

### Changes in utils.py:
- Added functions to parse property filters and apply them to nodes.
  - `convert_value`: Converts a value string to the appropriate type (int, float, or string).
  - `parse_property_filter`: Parses a property filter string into a key, operator, and value.
  - `node_matches_property_filters`: Checks if a node matches all provided property filters.
  - `filter_nodes_by_properties`: Filters a list of nodes based on the provided property filters. Prints a message if no nodes match the specified properties.

### Changes in node.py:
- Updated the `ListNode` command to include property filtering support.
  - Added `--property` argument to the parser for specifying property filters.
  - Applied property filters to the list of nodes retrieved from the client.
  - Printed a message if no nodes match the specified properties.

### Changes in test_node.py:
- Added test cases to verify the functionality of property filters in node listing.
  - `test_node_list_with_property_filter`: Verifies node listing with a property filter (`cpus>=40`).
  - `test_node_list_long_with_property_filter`: Verifies detailed node listing with a property filter (`memory_mb>=131072`).
