### PR TITLE
Clarify help text for --all and --status flags in esi lease list and offer list

### DIFF
--- a/esileapclient/osc/v1/lease.py
+++ b/esileapclient/osc/v1/lease.py
@@ -143,7 +143,11 @@ class ListLease(command.Lister):
             '--status',
             dest='status',
             required=False,
-            help="Show all leases with given status.")
+            help="Show all leases with the given status. "
+                 "Use --status 'any' to show leases with any status "
+                 "(by default, leases with 'created', 'active', 'error', "
+                 "'wait_cancel', 'wait_expire', and 'wait_fulfill' statuses "
+                 "are shown).")
         parser.add_argument(
             '--offer-uuid',
             dest='offer_uuid',

--- a/esileapclient/osc/v1/offer.py
+++ b/esileapclient/osc/v1/offer.py
@@ -107,7 +107,10 @@ class ListOffer(command.Lister):
             '--status',
             dest='status',
             required=False,
-            help="Show all offers with given status.")
+            help="Show all offers with the given status. "
+                 "Use --status 'any' to show offers with any status "
+                 "(by default, offers with 'available' and 'error' statuses"
+                 "are shown).")
         parser.add_argument(
             '--time-range',
             dest='time_range',


### PR DESCRIPTION
- Updated the help text for `openstack esi lease list` command to specify that --all shows all projects and --status any shows all statuses.
- Ensured similar clarity for `openstack esi offer list` command.