### PR TITLE
Remove version requirement for openstacksdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openstacksdk<1.3.0
+openstacksdk
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 python-openstackclient>=3.18.0
 six>=1.12.0


### PR DESCRIPTION
The `openstacksdk<1.3.0` requirement was to maintain compatibility with older versions of python we no longer support; it also results in impossible dependencies caused by newer openstack clients requiring newer versions of openstacksdk.