### PR TITLE
Fix erroneous use of "is"

### DIFF
--- a/esileapclient/tests/functional/base.py
+++ b/esileapclient/tests/functional/base.py
@@ -121,7 +121,7 @@ class ESIBaseTestClass(base.ClientTestBase):
             'domain': 'default'
         }
 
-        if roles is []:
+        if not roles:
             raise ValueError('No roles specified when initializing dummy \
                               project %s' % name)
         elif type(roles) is str:


### PR DESCRIPTION
The `is` operator checks for identity, not equality. To check for an empty
list, one should use either:

    if roles == []:

Or just take advantage of the fact that an empty list is `False` when used
in a boolean expression, and write:

    if not roles:

This commit takes the second option.
